### PR TITLE
renamed componentWillReceiveProps and componentWillMount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+/.idea

--- a/src/main.js
+++ b/src/main.js
@@ -27,13 +27,13 @@ class Geocoder extends Component {
     this.onResult = this.onResult.bind(this);
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.setState({ inputValue: this.props.defaultInputValue });
   }
   componentDidMount() {
     if (this.props.focusOnMount) ReactDOM.findDOMNode(this.refs.input).focus();
   }
-  componentWillReceiveProps(props) {
+  UNSAFE_componentWillReceiveProps(props) {
     if (props.defaultInputValue !== this.props.inputValue) {
       this.setState({ inputValue: props.defaultInputValue });
     }


### PR DESCRIPTION
I am getting a warning in the console that the UNSAFE_ prefix needs to be added to the deprecated lifecycle methods.  This pr renames componentWillReceiveProps and componentWillMount so that this warning is no longer shown.